### PR TITLE
fix(php): use the API/REST instead of the database

### DIFF
--- a/SOLID/DEPENDENCY_INVERSION/project/app.php
+++ b/SOLID/DEPENDENCY_INVERSION/project/app.php
@@ -12,7 +12,7 @@ $userArrayRepository = new UserRepository(new ArrayClient());
 $userJSONRepository = new UserRepository(new JSONClient());
 
 it('Array Client Works as expected', count($userArrayRepository->getUsers()) === 3);
-it('JSON Client Works as expected', count($userArrayRepository->getUsers()) === 3);
+it('JSON Client Works as expected', count($userJSONRepository->getUsers()) === 3);
 
 it(
     'Array Client : retrieve user by email',
@@ -22,6 +22,6 @@ it(
 
 it(
     'JSON Client : retrieve user by email',
-    $userArrayRepository->getUser('mathieu.nebra@exemple.com')
+    $userJSONRepository->getUser('mathieu.nebra@exemple.com')
         ->describe() === 'Mathieu Nebra (mathieu.nebra@exemple.com)'
 );


### PR DESCRIPTION
When we test the exercise from the `app.php` file, we use the database source (`$userArrayRepository`) and not the API/REST.